### PR TITLE
burn fix on burnAsset in ./utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "bubblegum-examples",
-  "version": "0.0.1",
+  "name": "compression-example",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "bubblegum-examples",
-      "version": "0.0.1",
-      "license": "Apache-2.0",
+      "name": "compression-example",
+      "version": "0.1.0",
       "dependencies": {
         "@metaplex-foundation/amman": "0.12.0",
         "@metaplex-foundation/beet": "^0.7.1",

--- a/utils.ts
+++ b/utils.ts
@@ -464,6 +464,11 @@ export const burnAsset = async (
   let assetProof = await connectionWrapper.getAssetProof(assetId);
   const rpcAsset = await connectionWrapper.getAsset(assetId);
   const leafNonce = rpcAsset.compression.leaf_id;
+  let proofPath = assetProof.proof.map((node: string) => ({
+    pubkey: new PublicKey(node),
+    isSigner: false,
+    isWritable: false,
+}));
   const treeAuthority = await getBubblegumAuthorityPDA(
     new PublicKey(assetProof.tree_id)
   );
@@ -478,6 +483,8 @@ export const burnAsset = async (
       merkleTree: new PublicKey(assetProof.tree_id),
       logWrapper: SPL_NOOP_PROGRAM_ID,
       compressionProgram: SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+      anchorRemainingAccounts: proofPath,
+
     },
     {
       root: bufferToArray(bs58.decode(assetProof.root)),


### PR DESCRIPTION
Additions
- Added proofPath and anchorRemainingAccounts to fix error "Invalid root recomputed from proof."